### PR TITLE
Chore: h2 database 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
+
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+

--- a/src/main/java/com/BEACON/beacon/dao/Member.java
+++ b/src/main/java/com/BEACON/beacon/dao/Member.java
@@ -1,0 +1,16 @@
+package com.BEACON.beacon.dao;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter @Setter
+public class Member {
+    @Id @GeneratedValue
+    private Long id;
+    private String username;
+
+}

--- a/src/main/java/com/BEACON/beacon/domain/MemberRepository.java
+++ b/src/main/java/com/BEACON/beacon/domain/MemberRepository.java
@@ -1,0 +1,23 @@
+package com.BEACON.beacon.domain;
+
+import com.BEACON.beacon.dao.Member;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MemberRepository {
+
+    @PersistenceContext
+    EntityManager em;
+
+    public Long save(Member member){
+        em.persist(member);
+        return member.getId();
+    }
+
+    public Member find(Long id){
+        return em.find(Member.class, id);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.profiles.include = aws

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/beacon
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+
+logging.level:
+  org.hibernate.SQL: debug

--- a/src/test/java/com/BEACON/beacon/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/BEACON/beacon/domain/MemberRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.BEACON.beacon.domain;
+
+import com.BEACON.beacon.dao.Member;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class MemberRepositoryTest {
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    @Transactional
+    @Rollback(false)
+    public void testMember(){
+        Member member = new Member();
+        member.setUsername("memberA");
+        Long savedId = memberRepository.save(member);
+        Member findMember = memberRepository.find(savedId);
+        Assertions.assertThat(findMember.getId()).isEqualTo(member.getId());
+
+        Assertions.assertThat(findMember.getUsername()).isEqualTo(member.getUsername());
+        Assertions.assertThat(findMember).isEqualTo(member); //JPA 엔티티 동일성 보
+
+    }
+
+
+}


### PR DESCRIPTION
계층형구조로 보기 쉽기 때문에 .properties파일에서 .yml파일로 바꿨습니다. 인메모리 DB를 쓰기위해 각자 로컬에서 DB를 MySQL이 아닌 H2데이터베이스를 쓸 수 있게 h2 DB를 설정하였습니다. 마지막으로 해당 테스트를 진행할 수 있게 테스트코드를 작성하였습니다. 테스트 하시고 지우시면 되겠습니다.