### PR TITLE
Feat: 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.2.0'
+
+	//spring-session-jdbc
+	implementation group: 'org.springframework.session', name: 'spring-session-jdbc', version: '3.0.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/BEACON/beacon/global/HttpStatusResponse.java
+++ b/src/main/java/com/BEACON/beacon/global/HttpStatusResponse.java
@@ -3,13 +3,15 @@ package com.BEACON.beacon.global;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class HttpStatusResponse {
+public interface HttpStatusResponse {
     //200
-    public static final ResponseEntity<HttpStatus> RESPONSE_OK = ResponseEntity.status(HttpStatus.OK).build();
+     ResponseEntity<HttpStatus> RESPONSE_OK = ResponseEntity.status(HttpStatus.OK).build();
     // 201
-    public static final ResponseEntity<HttpStatus> RESPONSE_CREATED = ResponseEntity.status(HttpStatus.CREATED).build();
+     ResponseEntity<HttpStatus> RESPONSE_CREATED = ResponseEntity.status(HttpStatus.CREATED).build();
     //403
-    public static final ResponseEntity<HttpStatus> RESPONSE_FORBIDDEN = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+     ResponseEntity<HttpStatus> RESPONSE_FORBIDDEN = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     //409
-    public static final ResponseEntity<HttpStatus> RESPONSE_CONFLICT = ResponseEntity.status(HttpStatus.CONFLICT).build();
+     ResponseEntity<HttpStatus> RESPONSE_CONFLICT = ResponseEntity.status(HttpStatus.CONFLICT).build();
+    //400
+     ResponseEntity<HttpStatus> RESPONSE_BAD_REQUEST = ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
 }

--- a/src/main/java/com/BEACON/beacon/global/annotation/LoginRequired.java
+++ b/src/main/java/com/BEACON/beacon/global/annotation/LoginRequired.java
@@ -1,0 +1,8 @@
+package com.BEACON.beacon.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginRequired {
+}

--- a/src/main/java/com/BEACON/beacon/global/config/WebConfig.java
+++ b/src/main/java/com/BEACON/beacon/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.BEACON.beacon.global.config;
+
+import com.BEACON.beacon.global.interceptor.LoginInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginInterceptor loginInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(loginInterceptor);
+    }
+}

--- a/src/main/java/com/BEACON/beacon/global/error/exception/MemberNotFoundException.java
+++ b/src/main/java/com/BEACON/beacon/global/error/exception/MemberNotFoundException.java
@@ -1,0 +1,12 @@
+package com.BEACON.beacon.global.error.exception;
+
+public class MemberNotFoundException extends RuntimeException{
+
+    public MemberNotFoundException(){
+    }
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/BEACON/beacon/global/error/exception/UnAuthenticatedAccessException.java
+++ b/src/main/java/com/BEACON/beacon/global/error/exception/UnAuthenticatedAccessException.java
@@ -1,0 +1,10 @@
+package com.BEACON.beacon.global.error.exception;
+
+public class UnAuthenticatedAccessException extends RuntimeException{
+    public UnAuthenticatedAccessException(){
+    }
+
+    public UnAuthenticatedAccessException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/BEACON/beacon/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/BEACON/beacon/global/interceptor/LoginInterceptor.java
@@ -1,0 +1,30 @@
+package com.BEACON.beacon.global.interceptor;
+
+import com.BEACON.beacon.global.annotation.LoginRequired;
+import com.BEACON.beacon.global.error.exception.UnAuthenticatedAccessException;
+import com.BEACON.beacon.member.service.SessionLoginService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+@Component
+@RequiredArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+    private final SessionLoginService loginService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,Object handler)throws Exception {
+        if (handler instanceof HandlerMethod && ((HandlerMethod) handler).hasMethodAnnotation(LoginRequired.class)) {
+            Object member = loginService.getLoginMember(request);
+
+
+            if (member == null) {
+                throw new UnAuthenticatedAccessException("인증되지 않은 회원은 접근할 수 없습니다");
+            }
+
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/BEACON/beacon/member/controller/MemberController.java
+++ b/src/main/java/com/BEACON/beacon/member/controller/MemberController.java
@@ -1,12 +1,12 @@
 package com.BEACON.beacon.member.controller;
 
+import com.BEACON.beacon.global.annotation.LoginRequired;
 import com.BEACON.beacon.member.domain.MemberEntity;
 import com.BEACON.beacon.member.dto.MemberDto;
 import com.BEACON.beacon.member.request.MemberLoginRequestDto;
 import com.BEACON.beacon.member.service.MemberService;
 import com.BEACON.beacon.member.service.SessionLoginService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -62,8 +62,8 @@ public class MemberController {
 
     /**
      * 로그인을 요청.
-     * @param memberDto
-     * @param request
+     * @param memberDto : 클라이언트에서 입력된 로그인 요청(아이디,비밀번호)
+     * @param request : Http Request
      * @return
      * 200: 로그인 성공
      * 400: 유효하지 않은 유저아이디 / 비밀번호 입니다
@@ -78,6 +78,19 @@ public class MemberController {
             return RESPONSE_OK;
         }
         return RESPONSE_BAD_REQUEST;
+    }
+
+
+    /**
+     * 로그아웃 처리
+     * @param request
+     * @return 200 : 로그아웃 성공
+     */
+    @LoginRequired
+    @GetMapping("/logout")
+    public ResponseEntity<HttpStatus> logout(HttpServletRequest request) {
+        sessionLoginService.logout(request);
+        return RESPONSE_OK;
     }
 
 }

--- a/src/main/java/com/BEACON/beacon/member/controller/MemberController.java
+++ b/src/main/java/com/BEACON/beacon/member/controller/MemberController.java
@@ -2,7 +2,11 @@ package com.BEACON.beacon.member.controller;
 
 import com.BEACON.beacon.member.domain.MemberEntity;
 import com.BEACON.beacon.member.dto.MemberDto;
+import com.BEACON.beacon.member.request.MemberLoginRequestDto;
 import com.BEACON.beacon.member.service.MemberService;
+import com.BEACON.beacon.member.service.SessionLoginService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,7 +23,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
-
+    private final SessionLoginService sessionLoginService;
 
     /**
      * 고객이 입력한 정보로 회원가입을 진행한다.
@@ -56,6 +60,25 @@ public class MemberController {
         return RESPONSE_OK;
     }
 
+    /**
+     * 로그인을 요청.
+     * @param memberDto
+     * @param request
+     * @return
+     * 200: 로그인 성공
+     * 400: 유효하지 않은 유저아이디 / 비밀번호 입니다
+     */
+    @PostMapping("/login")
+    public ResponseEntity<HttpStatus> login(@RequestBody @Valid MemberLoginRequestDto memberDto, HttpServletRequest request){
+
+        boolean isValidMember = memberService.isValidMember(memberDto,passwordEncoder);
+
+        if(isValidMember){
+            sessionLoginService.login(memberDto.getUserId(),request);
+            return RESPONSE_OK;
+        }
+        return RESPONSE_BAD_REQUEST;
+    }
 
 }
 

--- a/src/main/java/com/BEACON/beacon/member/dao/MemberRepository.java
+++ b/src/main/java/com/BEACON/beacon/member/dao/MemberRepository.java
@@ -3,12 +3,14 @@ package com.BEACON.beacon.member.dao;
 import com.BEACON.beacon.member.domain.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<MemberEntity,Long> {
 
     boolean existsByUserId(String userId);
 
     boolean existsByEmail(String email);
 
-
+    Optional<MemberEntity> findMemberByUserId(String userId);
 
 }

--- a/src/main/java/com/BEACON/beacon/member/dto/SessionDto.java
+++ b/src/main/java/com/BEACON/beacon/member/dto/SessionDto.java
@@ -1,0 +1,14 @@
+package com.BEACON.beacon.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+@Builder
+public class SessionDto implements Serializable {
+    private String userId;
+    private String password;
+
+}

--- a/src/main/java/com/BEACON/beacon/member/dto/SessionDto.java
+++ b/src/main/java/com/BEACON/beacon/member/dto/SessionDto.java
@@ -9,6 +9,4 @@ import java.io.Serializable;
 @Builder
 public class SessionDto implements Serializable {
     private String userId;
-    private String password;
-
 }

--- a/src/main/java/com/BEACON/beacon/member/request/MemberLoginRequestDto.java
+++ b/src/main/java/com/BEACON/beacon/member/request/MemberLoginRequestDto.java
@@ -1,0 +1,14 @@
+package com.BEACON.beacon.member.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class MemberLoginRequestDto {
+    @NotEmpty
+    private String userId;
+    @NotEmpty
+    private String password;
+}

--- a/src/main/java/com/BEACON/beacon/member/service/MemberService.java
+++ b/src/main/java/com/BEACON/beacon/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package com.BEACON.beacon.member.service;
 
+import com.BEACON.beacon.global.error.exception.MemberNotFoundException;
 import com.BEACON.beacon.member.dao.MemberRepository;
 import com.BEACON.beacon.member.domain.MemberEntity;
+import com.BEACON.beacon.member.request.MemberLoginRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,5 +40,32 @@ public class MemberService {
     public boolean isDuplicatedEmail(String email){
         return memberRepository.existsByEmail(email);
     }
+
+
+    /**
+     * 사용자가 입력한 비밀번호가 유효한지 검사
+     * @param memberDto
+     * @param passwordEncoder
+     * @return 아이디와 비밀번호가 일치하면 true 아니면 false 반환
+     */
+    public boolean isValidMember(MemberLoginRequestDto memberDto, PasswordEncoder passwordEncoder){
+        MemberEntity member = findMemberByUserId(memberDto.getUserId());
+
+        if(passwordEncoder.matches(memberDto.getPassword(),member.getPassword())){
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * 사용자가 입력한 아이디가 존재하는 지 검사
+     * @param userId
+     * @return MemberEntity or Exception
+     */
+    protected MemberEntity findMemberByUserId(String userId){
+        return memberRepository.findMemberByUserId(userId).orElseThrow(()->new MemberNotFoundException("가입된 회원이 아닙니다"));
+    }
+
 
 }

--- a/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
+++ b/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
@@ -1,0 +1,27 @@
+package com.BEACON.beacon.member.service;
+
+import com.BEACON.beacon.member.domain.MemberEntity;
+import com.BEACON.beacon.member.dto.SessionDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SessionLoginService {
+    private final MemberService memberService;
+    public static final String LOGIN_MEMBER = "loginMember";
+
+    public void login(String userId, HttpServletRequest request){
+        MemberEntity member = memberService.findMemberByUserId(userId);
+
+        SessionDto sessionDto = SessionDto.builder()
+                .userId(member.getUserId())
+                .password(member.getPassword())
+                .build();
+
+        HttpSession session = request.getSession();
+        session.setAttribute(LOGIN_MEMBER,sessionDto);
+    }
+}

--- a/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
+++ b/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
@@ -23,5 +23,20 @@ public class SessionLoginService {
 
         HttpSession session = request.getSession();
         session.setAttribute(LOGIN_MEMBER,sessionDto);
+        //세션 만료시간 무한대
+        session.setMaxInactiveInterval(-1);
+    }
+
+    public void logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if(session!=null){
+            session.removeAttribute(LOGIN_MEMBER);
+        }
+    }
+
+    public Object getLoginMember(HttpServletRequest request){
+        HttpSession session = request.getSession();
+
+        return session.getAttribute(LOGIN_MEMBER);
     }
 }

--- a/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
+++ b/src/main/java/com/BEACON/beacon/member/service/SessionLoginService.java
@@ -18,7 +18,6 @@ public class SessionLoginService {
 
         SessionDto sessionDto = SessionDto.builder()
                 .userId(member.getUserId())
-                .password(member.getPassword())
                 .build();
 
         HttpSession session = request.getSession();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  session:
+    jdbc:
+      initialize-schema: always
+
 
 logging.level:
   org.hibernate.SQL: debug
@@ -26,3 +30,4 @@ springdoc:
     path: /swagger
   api-docs:
     path: /api-docs/json
+

--- a/src/test/java/com/BEACON/beacon/member/service/SessionLoginServiceTest.java
+++ b/src/test/java/com/BEACON/beacon/member/service/SessionLoginServiceTest.java
@@ -1,0 +1,49 @@
+package com.BEACON.beacon.member.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class SessionLoginServiceTest {
+
+    private static final String LOGIN_MEMBER = "loginMember";
+    private MockHttpServletRequest request;
+    private MockHttpSession session;
+    private SessionLoginService sessionLoginService;
+
+
+    @Mock
+    private MemberService memberService;
+
+
+
+    @BeforeEach
+    void setUp() {
+        sessionLoginService = new SessionLoginService(memberService);
+        request = new MockHttpServletRequest();
+        session = new MockHttpSession();
+        request.setSession(session);
+    }
+
+    @Test
+    @DisplayName("로그인한 세션이 없을 때 null 값 반환하는 지 테스트")
+    void getLoginMemberIsNull(){
+      Object member =   session.getAttribute(LOGIN_MEMBER);
+      assertEquals(null,member,"member에는 아무것도 없어야 한다");
+    }
+
+    @Test
+    @DisplayName("로그인한 세션이 있을 때 Object가 반환되는지 테스트")
+    void getLoginMemberIsNotNull(){
+
+    }
+}


### PR DESCRIPTION
- 세션 기반 로그인 이며 세션 저장소로 H2 데이터베이스로 설정(배포때 변경가능) 
세션 저장을 하는 이유는 배포 후 서버 재시작 이후에도 강제 로그아웃을 막기 위함이며 추후에 다중 서버 이용시 세션 공유를 하기 위함 입니다
- LoginRequired 어노테이션 추가 
이제 해당 어노테이션을 인증이 필요한 api 위에 적으면 로그인한 회원인지 확인을 하도록 했습니다 
- 테스트 코드는 작성중 
현재 MemberControllerTest는 추가적인 주입을 하지 않아 테스트를 통과하지 못하고 있습니다
테스트코드는 작성하는 데 시간이 너무 걸려 다른 모든 구현 이후에 작성하겠습니다
-  일단은 postman으로 api 테스트를 하고 정상적으로 되는 것을 확인했습니다 