### PR TITLE
Feat: FCM 서버 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ out/
 
 ### application profile ###
 application-aws.properties
+
+### Firebase ###
+.idea
+**/node_modules/*
+**/.firebaserc
+
+### Firebase Patch ###
+.runtimeconfig.json
+.firebase/

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // swagger
+	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.2.0'
 
@@ -53,6 +53,12 @@ dependencies {
 	// h2
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'com.h2database:h2'
+
+	//firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+	// okhttp
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
 
 }
 

--- a/src/main/java/com/BEACON/beacon/fcm/FcmMessage.java
+++ b/src/main/java/com/BEACON/beacon/fcm/FcmMessage.java
@@ -1,0 +1,46 @@
+package com.BEACON.beacon.fcm;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+
+@Builder
+@Getter
+public class FcmMessage {
+    private boolean validate_only;
+    private Message message;
+
+    public FcmMessage(boolean validate_only, Message message) {
+        this.validate_only = validate_only;
+        this.message = message;
+    }
+
+    @Builder
+    @Getter
+    public static class Message {
+        private Notification notification;
+        private String token;
+
+        public Message(Notification notification, String token) {
+            this.notification = notification;
+            this.token = token;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+
+        public Notification(String title, String body, String image) {
+            this.title = title;
+            this.body = body;
+            this.image = image;
+        }
+    }
+
+}

--- a/src/main/java/com/BEACON/beacon/fcm/UserType.java
+++ b/src/main/java/com/BEACON/beacon/fcm/UserType.java
@@ -1,0 +1,6 @@
+package com.BEACON.beacon.fcm;
+
+public enum UserType {
+    MEMBER,
+    NON_MEMBER
+}

--- a/src/main/java/com/BEACON/beacon/fcm/controller/FcmTokenController.java
+++ b/src/main/java/com/BEACON/beacon/fcm/controller/FcmTokenController.java
@@ -1,0 +1,33 @@
+package com.BEACON.beacon.fcm.controller;
+
+import com.BEACON.beacon.fcm.dto.FcmTokenDto;
+import com.BEACON.beacon.fcm.service.FcmTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.BEACON.beacon.global.HttpStatusResponse.RESPONSE_CREATED;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+
+    /**
+     * FCM 토큰을 수신받기 위한 메서드
+     * @return 200
+     */
+    @PostMapping("/token")
+    public ResponseEntity<HttpStatus> tokenRegister(@RequestBody FcmTokenDto fcmTokenDto){
+        fcmTokenService.addFcmToken(fcmTokenDto);
+
+        return RESPONSE_CREATED;
+    }
+}

--- a/src/main/java/com/BEACON/beacon/fcm/dao/FcmTokenRepository.java
+++ b/src/main/java/com/BEACON/beacon/fcm/dao/FcmTokenRepository.java
@@ -1,0 +1,8 @@
+package com.BEACON.beacon.fcm.dao;
+
+import com.BEACON.beacon.fcm.domain.FcmTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface FcmTokenRepository extends JpaRepository<FcmTokenEntity,Long> {
+}

--- a/src/main/java/com/BEACON/beacon/fcm/domain/FcmTokenEntity.java
+++ b/src/main/java/com/BEACON/beacon/fcm/domain/FcmTokenEntity.java
@@ -1,0 +1,38 @@
+package com.BEACON.beacon.fcm.domain;
+
+import com.BEACON.beacon.fcm.UserType;
+import com.BEACON.beacon.member.domain.MemberEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "FCMTOKEN")
+public class FcmTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="ID")
+    private Long id;
+
+    @Column(name="TOKEN" , unique = true)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "USERTYPE")
+    private UserType userType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="MEMBER_ID")
+    private MemberEntity member;
+
+    public FcmTokenEntity(){
+    }
+    @Builder
+    public FcmTokenEntity(String token, UserType userType, MemberEntity member) {
+        this.token = token;
+        this.userType = userType;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/BEACON/beacon/fcm/dto/FcmTokenDto.java
+++ b/src/main/java/com/BEACON/beacon/fcm/dto/FcmTokenDto.java
@@ -1,0 +1,16 @@
+package com.BEACON.beacon.fcm.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class FcmTokenDto {
+    //토큰 , 회원 아이디
+    @NotEmpty
+    private String token;
+
+    private String username;
+
+
+
+}

--- a/src/main/java/com/BEACON/beacon/fcm/mapper/FcmTokenMapper.java
+++ b/src/main/java/com/BEACON/beacon/fcm/mapper/FcmTokenMapper.java
@@ -1,0 +1,26 @@
+package com.BEACON.beacon.fcm.mapper;
+
+import com.BEACON.beacon.fcm.UserType;
+import com.BEACON.beacon.fcm.domain.FcmTokenEntity;
+import com.BEACON.beacon.fcm.dto.FcmTokenDto;
+import com.BEACON.beacon.member.domain.MemberEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FcmTokenMapper {
+    public static FcmTokenEntity toMemberEntity(FcmTokenDto fcmTokenDto, MemberEntity member){
+        return FcmTokenEntity.builder()
+                .token(fcmTokenDto.getToken())
+                .userType(UserType.MEMBER)
+                .member(member)
+                .build();
+    }
+
+    public static FcmTokenEntity toNoNMemberEntity(FcmTokenDto fcmTokenDto){
+        return FcmTokenEntity.builder()
+                .token(fcmTokenDto.getToken())
+                .userType(UserType.NON_MEMBER)
+                .build();
+    }
+
+}

--- a/src/main/java/com/BEACON/beacon/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/BEACON/beacon/fcm/service/FcmTokenService.java
@@ -1,0 +1,35 @@
+package com.BEACON.beacon.fcm.service;
+
+import com.BEACON.beacon.fcm.dao.FcmTokenRepository;
+import com.BEACON.beacon.fcm.domain.FcmTokenEntity;
+import com.BEACON.beacon.fcm.dto.FcmTokenDto;
+import com.BEACON.beacon.fcm.mapper.FcmTokenMapper;
+import com.BEACON.beacon.member.domain.MemberEntity;
+import com.BEACON.beacon.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+    private final MemberService memberService;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenMapper fcmTokenMapper;
+
+    public void addFcmToken(FcmTokenDto fcmTokenDto){
+        MemberEntity member;
+        FcmTokenEntity fcmTokenEntity;
+
+        if(fcmTokenDto.getUsername()!=null){
+          member =  memberService.findMemberByUserId(fcmTokenDto.getUsername());
+          fcmTokenEntity =  fcmTokenMapper.toMemberEntity(fcmTokenDto,member);
+        }else{
+           fcmTokenEntity =  fcmTokenMapper.toNoNMemberEntity(fcmTokenDto);
+        }
+        fcmTokenRepository.save(fcmTokenEntity);
+    }
+
+
+
+
+}

--- a/src/main/java/com/BEACON/beacon/fcm/service/FirebaseCloudMessageService.java
+++ b/src/main/java/com/BEACON/beacon/fcm/service/FirebaseCloudMessageService.java
@@ -1,0 +1,75 @@
+package com.BEACON.beacon.fcm.service;
+
+import com.BEACON.beacon.fcm.FcmMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.net.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import okhttp3.*;
+
+
+import java.io.IOException;
+import java.util.List;
+@Service
+@RequiredArgsConstructor
+public class FirebaseCloudMessageService {
+
+    //beacon-f5f95
+    private final String API_URL = "https://fcm.googleapis.com/v1/projects/beacon-f5f95/messages:send";
+
+    private final ObjectMapper objectMapper;
+
+
+    private String getAccessToken() throws IOException {
+        String firebaseConfigPath = "firebase/beacon-f5f95-firebase-adminsdk-1eafi-7017a1d13e.json";
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+    public void sendMessageTo(String targetToken, String title, String body) throws IOException {
+        String message = makeMessage(targetToken, title, body);
+
+        OkHttpClient client = new OkHttpClient();
+
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                .build();
+
+        Response response = client.newCall(request)
+                .execute();
+
+        System.out.println(response.body().string());
+    }
+
+    private String makeMessage(String targetToken, String title, String body) throws JsonProcessingException {
+        FcmMessage fcmMessage = FcmMessage.builder()
+                .message(FcmMessage.Message.builder()
+                        .token(targetToken)
+                        .notification(FcmMessage.Notification.builder()
+                                .title(title)
+                                .body(body)
+                                .image(null)
+                                .build()
+                        )
+                        .build()
+                )
+                .validate_only(false)
+                .build();
+
+        return objectMapper.writeValueAsString(fcmMessage);
+    }
+
+
+}

--- a/src/main/java/com/BEACON/beacon/member/domain/MemberEntity.java
+++ b/src/main/java/com/BEACON/beacon/member/domain/MemberEntity.java
@@ -13,7 +13,7 @@ public class MemberEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="ID")
+    @Column(name="MEMBER_ID")
     private Long id;
 
 

--- a/src/main/java/com/BEACON/beacon/member/service/MemberService.java
+++ b/src/main/java/com/BEACON/beacon/member/service/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
      * @param userId
      * @return MemberEntity or Exception
      */
-    protected MemberEntity findMemberByUserId(String userId){
+    public MemberEntity findMemberByUserId(String userId){
         return memberRepository.findMemberByUserId(userId).orElseThrow(()->new MemberNotFoundException("가입된 회원이 아닙니다"));
     }
 


### PR DESCRIPTION
- 클라이언트에서 서버로 FCM 토큰을 전송할 API 엔드포인트 구현
- FCM을 사용하기위한 FCM 서비스 구현
- postman으로 테스트 완료 (JUnit5으로 추후에 pr 보내겠습니다)
- 다음 pr에서는 스크래핑을 한 재난문자를 회원과 비회원에게 푸시알림을 보낼 수 있도록 구현합니다