### PR TITLE
Refactor: 배포때 생겼던 문제 리펙토링 및 로그파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,11 @@ application-prod.yml
 ### Firebase Patch ###
 .runtimeconfig.json
 .firebase/
+firebase/beacon-f5f95-firebase-adminsdk-1eafi-7ab6bafbf7.json
 
+### 카카오 API 키
 src/main/resources/application-API-KEY.properties
+
+### 배포 설정 파일
+application-deploy.yml
+

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
 	// gson
 	implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
 
+
+	// mysql
+	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/BEACON/beacon/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/BEACON/beacon/fcm/service/FcmTokenService.java
@@ -12,6 +12,8 @@ import com.BEACON.beacon.region.dto.RegionAlertDto;
 import com.BEACON.beacon.scraping.dto.DisasterAlertDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class FcmTokenService {
+    private Logger logger = LoggerFactory.getLogger(FcmTokenService.class);
     private final MemberService memberService;
     private final FcmTokenRepository fcmTokenRepository;
     private final FcmTokenMapper fcmTokenMapper;
@@ -32,7 +35,7 @@ public class FcmTokenService {
         MemberEntity member;
         FcmTokenEntity fcmTokenEntity;
 
-        if(fcmTokenDto.getUserName()!=null){
+        if(!fcmTokenDto.getUserName().isEmpty()){
           member =  memberService.findMemberByUserName(fcmTokenDto.getUserName());
           fcmTokenEntity =  fcmTokenMapper.toMemberEntity(fcmTokenDto,member);
         }else{
@@ -60,6 +63,8 @@ public class FcmTokenService {
                 String FCMTitle = "재난문자";
                 firebaseCloudMessageService.sendMessageTo(token, FCMTitle,disasterAlertDto.getContent());
             } catch (IOException e) {
+                String detailMessage = String.format("IOException: 재난문자를 %s 토큰에 보내는 것을 실패하였습니다.",token);
+                logger.warn(detailMessage);
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/com/BEACON/beacon/fcm/service/FirebaseCloudMessageService.java
+++ b/src/main/java/com/BEACON/beacon/fcm/service/FirebaseCloudMessageService.java
@@ -24,7 +24,7 @@ public class FirebaseCloudMessageService {
 
 
     private String getAccessToken() throws IOException {
-        String firebaseConfigPath = "firebase/beacon-f5f95-firebase-adminsdk-1eafi-7017a1d13e.json";
+        String firebaseConfigPath = "firebase/beacon-f5f95-firebase-adminsdk-1eafi-7ab6bafbf7.json";
 
         GoogleCredentials googleCredentials = GoogleCredentials
                 .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())

--- a/src/main/java/com/BEACON/beacon/location/dto/LocationDto.java
+++ b/src/main/java/com/BEACON/beacon/location/dto/LocationDto.java
@@ -9,11 +9,11 @@ import lombok.Getter;
 @Schema(description = "위치 정보 및 fcm 토큰 전달 객체")
 public class LocationDto {
 
-    @NotEmpty
+
     @Schema(description = "위도")
     Double latitude;
 
-    @NotEmpty
+
     @Schema(description = "경도")
     Double longitude;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,8 +20,7 @@ spring:
     jdbc:
       initialize-schema: always
 
-logging.level:
-  org.hibernate.SQL: debug
+
 
 # swagger-ui path
 springdoc:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %yellow([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProfile name="!deploy">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="deploy">
+        <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/warn/warn-${BY_DATE}.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>10</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/error/error-${BY_DATE}.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="FILE_WARN"/>
+            <appender-ref ref="FILE_ERROR"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
- Double 타입 체크에 @notEmpty 사용한 것 수정
- fcmToken에 ""으로 json 전송시 isEmpty로 체크하도록 수정
- logback-spring.xml 추가 : spring profile을 dev로 설정하면 콘솔창에 로그들이 출력되며 배포할때는 deploy로 바꿔야 파일로 관리가 됩니다. 추가적으로 콘솔창에서는 로그레벨이 info이상이며 배포했을때 파일의 로그레벨은 warn과 error만을 관리하고 10일동안 파일을 관리하고 이후엔 삭제되며 한 파일에는 하루에 최대10MB까지 관리됩니다